### PR TITLE
Enhance normalize_datetime

### DIFF
--- a/src/Preprocessor.py
+++ b/src/Preprocessor.py
@@ -52,13 +52,20 @@ class Preprocessor:
     @staticmethod
     def normalize_datetime(input_value) -> str:
         if type(input_value) == dict:
-            if not input_value.get("Date") and input_value.get("Time"):
+            if not input_value.get("Date") and input_value.get("Time"): # Not possible to handle only Time
                 logging.warning("Encountered complex date field, but cannot interpret it")
                 return input_value
+            if input_value.get("Date") and not input_value.get("Time"): # Handle only Date
+                input_value["Time"] = "00:00:00"
+                logging.info("Input with date information but no time information found. Setting time to 00:00:00")
             input_value = input_value.get("Date") + " " + input_value.get("Time")
         output_value = parse_datetime(input_value)
         if type(output_value) == datetime:
-            return output_value.astimezone(timezone.utc).isoformat()
+            if output_value.tzinfo:
+                output_value = output_value.astimezone(timezone.utc) # datetime has timezone info, convert it to UTC
+            else:
+                output_value = output_value.replace(tzinfo=timezone.utc) # No timezone, assume it's already in UTC
+            return output_value.isoformat().replace("+00:00", "Z")
         return input_value
 
     @staticmethod

--- a/tests/parser_tests/test_preprocessor.py
+++ b/tests/parser_tests/test_preprocessor.py
@@ -2,6 +2,7 @@ import importlib
 from enum import Enum
 
 from src.Preprocessor import Preprocessor
+from src.model.SchemaConcepts.codegen.SchemaClasses_SEM import Entry
 
 
 class TestPreprocessor:
@@ -39,3 +40,39 @@ class TestPreprocessor:
         Preprocessor.normalize_all_units(input_dict)
         normalized_units = [x["unit"] for x in input_dict['some']['nested']['units']]
         assert not [x for x in normalized_units if x not in all_units]
+
+    def test_date_preprocessing(self):
+        input_date = {"Date": "12 Apr 2015", "Time": "14:15:00"}
+        normalized = Preprocessor.normalize_datetime(input_date)
+
+        semEntry = Entry(startTime=normalized)
+        assert semEntry.startTime == "2015-04-12T14:15:00Z"
+
+        input_date = {"Date": "2015/04/12", "Time": "14:15:00"}
+        normalized = Preprocessor.normalize_datetime(input_date)
+
+        semEntry = Entry(startTime=normalized)
+        assert semEntry.startTime == "2015-04-12T14:15:00Z"
+
+        input_date = {"Date": "2015/04/12", "Time": "14:15:00+03:00"}
+        normalized = Preprocessor.normalize_datetime(input_date)
+
+        semEntry = Entry(startTime=normalized)
+        assert semEntry.startTime == "2015-04-12T11:15:00Z"
+
+        input_date = {"Date": "2015/04/12", "Time": "14:15:00Z"}
+        normalized = Preprocessor.normalize_datetime(input_date)
+
+        semEntry = Entry(startTime=normalized)
+        assert semEntry.startTime == "2015-04-12T14:15:00Z"
+
+        input_date = {"Date": "12 Apr 2015"}
+        normalized = Preprocessor.normalize_datetime(input_date)
+
+        semEntry = Entry(startTime=normalized)
+        assert semEntry.startTime == "2015-04-12T00:00:00Z"
+
+        #input_date = {"Time": "14:15:00"}
+        #normalized = Preprocessor.normalize_datetime(input_date)
+
+        #semEntry = Entry(startTime=normalized)


### PR DESCRIPTION
This PR improves the `normalize_datetime` function and adds corresponding tests to ensure consistent and reliable datetime normalization.

**Changes made**:
- Handles date-only inputs by assuming default time to 00:00:00.
- Assumes UTC for default datetimes.
- Standardizes datetime with Z suffix at the end.
- Improved logging for incomplete inputs.
- Added test_date_preprocessing to cover multiple date formats with missing.

This PR closes issue #9 