### PR TITLE
Stricter typ handling for parser factory

### DIFF
--- a/src/parser/ParserFactory.py
+++ b/src/parser/ParserFactory.py
@@ -1,5 +1,9 @@
 import logging
+from typing import Dict, Type
 
+from src.parser.ImageParser import ImageParser
+from src.parser.RunMD_Parser import RunMD_Parser
+from src.parser.SetupMD_Parser import SetupMD_Parser
 from src.parser.impl.Atlas3dParser import Atlas3dParser
 from src.parser.impl.EMProjectParser import EMProjectParser
 from src.parser.impl.ProjectDataParser import ProjectDataParser
@@ -11,14 +15,14 @@ from src.parser.impl.TxtParser import TxtParser
 
 class ParserFactory:
 
-    available_setupmd_parsers = {
+    available_setupmd_parsers: Dict[str, Type[SetupMD_Parser]]  = {
         "EMProjectParser": EMProjectParser,
         "Atlas3DParser": Atlas3dParser,
         "TomographyProjectParser": TomographyProjectParser,
         "Dataset_infoParser": Dataset_infoParser
     }
 
-    available_runmd_parsers = {
+    available_runmd_parsers: Dict[str, Type[RunMD_Parser]] = {
         "ProjectDataParser": ProjectDataParser,
         "Atlas3DParser": Atlas3dParser,
         "TomographyProjectParser": TomographyProjectParser,
@@ -31,7 +35,7 @@ class ParserFactory:
     }
 
     @staticmethod
-    def create_setupmd_parser(parser_name):
+    def create_setupmd_parser(parser_name) -> SetupMD_Parser:
         parser_class = ParserFactory.available_setupmd_parsers.get(parser_name)
         if parser_class:
             return parser_class()
@@ -40,7 +44,7 @@ class ParserFactory:
             raise ValueError(f"Parser {parser_name} not found")
 
     @staticmethod
-    def create_runmd_parser(parser_name):
+    def create_runmd_parser(parser_name) -> RunMD_Parser:
         parser_class = ParserFactory.available_runmd_parsers.get(parser_name)
         if parser_class:
             return parser_class()
@@ -49,7 +53,7 @@ class ParserFactory:
             raise ValueError(f"Parser {parser_name} not found")
 
     @staticmethod
-    def create_img_parser(parser_name, **kwargs):
+    def create_img_parser(parser_name, **kwargs) -> ImageParser:
         parser_class = ParserFactory.available_img_parsers.get(parser_name)
         if parser_class:
             return parser_class(**kwargs)

--- a/src/parser/ParserFactory.py
+++ b/src/parser/ParserFactory.py
@@ -24,9 +24,7 @@ class ParserFactory:
 
     available_runmd_parsers: Dict[str, Type[RunMD_Parser]] = {
         "ProjectDataParser": ProjectDataParser,
-        "Atlas3DParser": Atlas3dParser,
-        "TomographyProjectParser": TomographyProjectParser,
-        "Dataset_infoParser": Dataset_infoParser
+        "Atlas3DParser": Atlas3dParser
     }
 
     available_img_parsers = {

--- a/tests/io_tests/tomo/test_mapreader.py
+++ b/tests/io_tests/tomo/test_mapreader.py
@@ -6,8 +6,10 @@ import tempfile
 import pytest
 
 from src.IO.tomo.MapfileReader import MapFileReader
+from src.parser.impl.Atlas3dParser import Atlas3dParser
 
 from src.parser.impl.Dataset_infoParser import Dataset_infoParser
+from src.parser.impl.ProjectDataParser import ProjectDataParser
 from src.parser.impl.TomographyProjectParser import TomographyProjectParser
 
 class TestMapfileReader:
@@ -121,15 +123,15 @@ class TestMapfileReader:
         test_map = {
             "run info": {
                 "sources": ["./src1.xml", "./src2.xml"],
-                "parser": "TomographyProjectParser"
+                "parser": "Atlas3DParser"
             }
         }
-        setupmdPairs = MapFileReader.parse_mapinfo_for_run(test_map)
-        for item in setupmdPairs: # [("./src1.xml", <"TomographyProjectParser" instance>), ("./src2.xml", <"TomographyProjectParser" instance>)]
+        runmdPairs = MapFileReader.parse_mapinfo_for_run(test_map)
+        for item in runmdPairs: # [("./src1.xml", <"TomographyProjectParser" instance>), ("./src2.xml", <"TomographyProjectParser" instance>)]
             assert len(item) == 2
-        assert len(setupmdPairs) == 2 
-        assert isinstance(setupmdPairs[0][1], TomographyProjectParser)
-        assert isinstance(setupmdPairs[1][1], TomographyProjectParser)
+        assert len(runmdPairs) == 2
+        assert isinstance(runmdPairs[0][1], Atlas3dParser)
+        assert isinstance(runmdPairs[1][1], Atlas3dParser)
 
     def test_parser_sources_list_matching_run(self):
         """
@@ -137,14 +139,14 @@ class TestMapfileReader:
         """
         test_map = {
             "run info": {
-                "sources": ["./src1.hdr", "./src2.xml"],
-                "parser": ["Dataset_infoParser", "TomographyProjectParser"]
+                "sources": ["./src1.xml", "./src2.xml"],
+                "parser": ["ProjectDataParser", "Atlas3DParser"]
             }
         }
-        setupmdPairs = MapFileReader.parse_mapinfo_for_run(test_map)
-        for item in setupmdPairs: # [("./src1.hdr", <"TomographyProjectParser" instance>), ("./src2.xml", <"TomographyProjectParser" instance>)]
+        runmdPairs = MapFileReader.parse_mapinfo_for_run(test_map)
+        for item in runmdPairs: # [("./src1.hdr", <"TomographyProjectParser" instance>), ("./src2.xml", <"TomographyProjectParser" instance>)]
             assert len(item) == 2
-        assert len(setupmdPairs) == 2 
-        assert isinstance(setupmdPairs[0][1], Dataset_infoParser)
-        assert isinstance(setupmdPairs[1][1], TomographyProjectParser)
+        assert len(runmdPairs) == 2
+        assert isinstance(runmdPairs[0][1], ProjectDataParser)
+        assert isinstance(runmdPairs[1][1], Atlas3dParser)
 


### PR DESCRIPTION
Dataset_infoParser and TomographyProjectParser removed from run parsers in factory, since they are not of correct type

somewhat closes #64 